### PR TITLE
fix: Change tabWidth in prettier

### DIFF
--- a/docs/prettierrc/prettierrc.md
+++ b/docs/prettierrc/prettierrc.md
@@ -6,7 +6,7 @@
 {
   "semi": true,
   "singleQuote": false,
-  "tabWidth": 2,
+  "tabWidth": 4,
   "jsxSingleQuote": false,
   "brackeSpacing": true,
   "trailingComma": "all",


### PR DESCRIPTION
### Изменена ширина табуляции в примере конфигурационного кода для Prettier
` "tabWidth": 4`